### PR TITLE
chore: bump Go version to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zoispag/go-python-runner
 
-go 1.21
+go 1.26
 
 require github.com/sirupsen/logrus v1.9.3
 


### PR DESCRIPTION
Bumps the minimum Go version in `go.mod` from `1.21` to `1.26` (current latest stable).

- `go build ./...` ✅
- `go vet ./...` ✅