### PR TITLE
refactor: misc code quality improvements

### DIFF
--- a/python/pep518.go
+++ b/python/pep518.go
@@ -1,13 +1,18 @@
 package python
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func pep518Proc(path string) {
 	tomlContent := readPyProjectToml(path)
+	if tomlContent == "" {
+		return
+	}
 
 	if isUv(path) {
 		uvProc(path)
@@ -17,12 +22,11 @@ func pep518Proc(path string) {
 }
 
 func readPyProjectToml(path string) string {
-	// read the whole file at once
-	b, err := ioutil.ReadFile(filepath.Join(path, "pyproject.toml"))
+	b, err := os.ReadFile(filepath.Join(path, "pyproject.toml"))
 	if err != nil {
-		panic(err)
+		log.Error(err.Error())
+		return ""
 	}
-
 	return string(b)
 }
 

--- a/python/pip.go
+++ b/python/pip.go
@@ -1,7 +1,6 @@
 package python
 
 import (
-	"fmt"
 	"os/exec"
 	"path/filepath"
 
@@ -11,23 +10,19 @@ import (
 func pipProc(path string) {
 	log.Info("Found 'requirements.txt'. Creating virtual environment using 'pip' & 'venv' module.")
 
-	var cmd *exec.Cmd
-
-	// create virtual env
-	cmd = exec.Command("python3", "-m", "venv", ".venv")
+	cmd := exec.Command("python3", "-m", "venv", ".venv")
 	cmd.Dir = path
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Error(fmt.Sprintf("%s", err.Error()))
+		log.Error(err.Error())
 	}
 	log.Debug(string(out))
 
-	// install dependencies
 	cmd = exec.Command(filepath.Join(path, ".venv/bin/pip"), "install", "-r", "requirements.txt")
 	cmd.Dir = path
 	out, err = cmd.CombinedOutput()
 	if err != nil {
-		log.Error(fmt.Sprintf("%s", err.Error()))
+		log.Error(err.Error())
 	}
 	log.Debug(string(out))
 }

--- a/python/pip.go
+++ b/python/pip.go
@@ -10,6 +10,7 @@ import (
 func pipProc(path string) {
 	log.Info("Found 'requirements.txt'. Creating virtual environment using 'pip' & 'venv' module.")
 
+	// create virtual env
 	cmd := exec.Command("python3", "-m", "venv", ".venv")
 	cmd.Dir = path
 	out, err := cmd.CombinedOutput()
@@ -18,6 +19,7 @@ func pipProc(path string) {
 	}
 	log.Debug(string(out))
 
+	// install dependencies
 	cmd = exec.Command(filepath.Join(path, ".venv/bin/pip"), "install", "-r", "requirements.txt")
 	cmd.Dir = path
 	out, err = cmd.CombinedOutput()

--- a/python/pipenv.go
+++ b/python/pipenv.go
@@ -1,7 +1,6 @@
 package python
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 
@@ -11,15 +10,13 @@ import (
 func pipenvProc(path string) {
 	log.Info("Found 'Pipfile'. Creating virtual environment using 'pipenv'.")
 
-	// Make sure .venv will be in project
 	os.Setenv("PIPENV_VENV_IN_PROJECT", "1")
 
-	// install dependencies
 	cmd := exec.Command("pipenv", "install")
 	cmd.Dir = path
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Error(fmt.Sprintf("%s", err.Error()))
+		log.Error(err.Error())
 	}
 	log.Debug(string(out))
 }

--- a/python/pipenv.go
+++ b/python/pipenv.go
@@ -10,8 +10,10 @@ import (
 func pipenvProc(path string) {
 	log.Info("Found 'Pipfile'. Creating virtual environment using 'pipenv'.")
 
+	// Make sure .venv will be in project
 	os.Setenv("PIPENV_VENV_IN_PROJECT", "1")
 
+	// install dependencies
 	cmd := exec.Command("pipenv", "install")
 	cmd.Dir = path
 	out, err := cmd.CombinedOutput()

--- a/python/poetry.go
+++ b/python/poetry.go
@@ -1,8 +1,8 @@
 package python
 
 import (
-	"fmt"
 	"os/exec"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -10,23 +10,21 @@ import (
 func poetryProc(path string) {
 	log.Info("Found 'pyproject.toml'. Creating virtual environment using 'Poetry'.")
 
-	// Make sure .venv will be in project
-	if !fileExists("poetry.toml") {
+	if !fileExists(filepath.Join(path, "poetry.toml")) {
 		cmd := exec.Command("poetry", "config", "--local", "virtualenvs.in-project", "true")
 		cmd.Dir = path
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			log.Error(fmt.Sprintf("%s", err.Error()))
+			log.Error(err.Error())
 		}
 		log.Debug(string(out))
 	}
 
-	// install dependencies
 	cmd := exec.Command("poetry", "install")
 	cmd.Dir = path
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Error(fmt.Sprintf("%s", err.Error()))
+		log.Error(err.Error())
 	}
 	log.Debug(string(out))
 }

--- a/python/poetry.go
+++ b/python/poetry.go
@@ -10,6 +10,7 @@ import (
 func poetryProc(path string) {
 	log.Info("Found 'pyproject.toml'. Creating virtual environment using 'Poetry'.")
 
+	// Make sure .venv will be in project
 	if !fileExists(filepath.Join(path, "poetry.toml")) {
 		cmd := exec.Command("poetry", "config", "--local", "virtualenvs.in-project", "true")
 		cmd.Dir = path
@@ -20,6 +21,7 @@ func poetryProc(path string) {
 		log.Debug(string(out))
 	}
 
+	// install dependencies
 	cmd := exec.Command("poetry", "install")
 	cmd.Dir = path
 	out, err := cmd.CombinedOutput()

--- a/python/run.go
+++ b/python/run.go
@@ -8,21 +8,16 @@ import (
 func getPythonCommand(path string) string {
 	if dirExists(filepath.Join(path, "./.venv")) {
 		return filepath.Join(path, ".venv/bin/python")
-	} else {
-		return "python"
 	}
+	return "python"
 }
 
 // GetPythonRunCommand Returns an *exec.Cmd to be handled with the provided "scriptName.py" using the python binary from virtual environment
 func GetPythonRunCommand(path string, scriptName string) *exec.Cmd {
-	pythonPath := getPythonCommand(path)
-	return exec.Command(pythonPath, scriptName)
+	return exec.Command(getPythonCommand(path), scriptName)
 }
 
 // ExecutePython Executes the provided "scriptName.py" using the python binary from virtual environment
 func ExecutePython(path string, scriptName string) ([]byte, error) {
-	// run python job
-	pythonPath := getPythonCommand(path)
-	cmd := exec.Command(pythonPath, scriptName)
-	return cmd.CombinedOutput()
+	return GetPythonRunCommand(path, scriptName).CombinedOutput()
 }

--- a/python/uv.go
+++ b/python/uv.go
@@ -1,7 +1,6 @@
 package python
 
 import (
-	"fmt"
 	"os/exec"
 
 	log "github.com/sirupsen/logrus"
@@ -10,12 +9,11 @@ import (
 func uvProc(path string) {
 	log.Info("Found 'uv.lock'. Creating virtual environment using 'uv'.")
 
-	// install dependencies
 	cmd := exec.Command("uv", "sync")
 	cmd.Dir = path
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Error(fmt.Sprintf("%s", err.Error()))
+		log.Error(err.Error())
 	}
 	log.Debug(string(out))
 }

--- a/python/uv.go
+++ b/python/uv.go
@@ -9,6 +9,7 @@ import (
 func uvProc(path string) {
 	log.Info("Found 'uv.lock'. Creating virtual environment using 'uv'.")
 
+	// install dependencies
 	cmd := exec.Command("uv", "sync")
 	cmd.Dir = path
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
## Changes

- **`pep518.go`**: replace deprecated `ioutil.ReadFile` with `os.ReadFile` (safe now that we're on Go 1.26)
- **`pep518.go`**: replace `panic` with `log.Error` + early return when `pyproject.toml` can't be read — consistent with the rest of the codebase
- **`poetry.go`**: fix longstanding CWD-relative bug — `fileExists("poetry.toml")` → `fileExists(filepath.Join(path, "poetry.toml"))`, so it correctly checks the project directory rather than the process CWD
- **`run.go`**: `ExecutePython` now delegates to `GetPythonRunCommand` instead of duplicating the same logic; drop redundant `else` after early return
- **All handlers**: simplify `log.Error(fmt.Sprintf("%s", err.Error()))` → `log.Error(err.Error())` — `err.Error()` already returns a string
- **`go mod tidy`**: clean up `go.sum`

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test -v -timeout 120s ./python/ -run TestE2E` — all 4 pass ✅